### PR TITLE
Display installed package versions in Versions panel

### DIFF
--- a/flask_debugtoolbar/panels/versions.py
+++ b/flask_debugtoolbar/panels/versions.py
@@ -1,5 +1,4 @@
 from distutils.sysconfig import get_python_lib
-import sys
 
 from flask import __version__ as flask_version
 from flask_debugtoolbar.panels import DebugPanel
@@ -27,17 +26,14 @@ class VersionDebugPanel(DebugPanel):
 
     def content(self):
         try:
-            from yolk import yolklib
+            import pkg_resources
         except ImportError:
-            "Requires yolk to provide package information"
             context = self.context.copy()
             context.update({
-                'packages': [],
-                'paths': sys.path
+                'packages': []
                 })
         else:
-            dist = yolklib.Distributions()
-            active_packages = dist.get_packages('active')
+            active_packages = pkg_resources.WorkingSet()
             _pkgs = dict([(p.project_name, p) for p in active_packages])
             packages = [_pkgs[key] for key in sorted(_pkgs.iterkeys())]
             for package in packages:
@@ -45,8 +41,7 @@ class VersionDebugPanel(DebugPanel):
 
             context = self.context.copy()
             context.update({
-                'packages': packages,
-                'paths': sys.path,
+                'packages': packages
             })
 
         return self.render('panels/versions.html', context)

--- a/flask_debugtoolbar/panels/versions.py
+++ b/flask_debugtoolbar/panels/versions.py
@@ -1,3 +1,6 @@
+from distutils.sysconfig import get_python_lib
+import sys
+
 from flask import __version__ as flask_version
 from flask_debugtoolbar.panels import DebugPanel
 
@@ -8,7 +11,7 @@ class VersionDebugPanel(DebugPanel):
     Panel that displays the Flask version.
     """
     name = 'Version'
-    has_content = False
+    has_content = True
 
     def nav_title(self):
         return _('Versions')
@@ -23,6 +26,27 @@ class VersionDebugPanel(DebugPanel):
         return _('Versions')
 
     def content(self):
-        return None
+        try:
+            from yolk import yolklib
+        except ImportError:
+            "Requires yolk to provide package information"
+            context = self.context.copy()
+            context.update({
+                'packages': [],
+                'paths': sys.path
+                })
+        else:
+            dist = yolklib.Distributions()
+            active_packages = dist.get_packages('active')
+            _pkgs = dict([(p.project_name, p) for p in active_packages])
+            packages = [_pkgs[key] for key in sorted(_pkgs.iterkeys())]
+            for package in packages:
+                package.develop_mode = not (package.location.lower().startswith(get_python_lib().lower()))
 
+            context = self.context.copy()
+            context.update({
+                'packages': packages,
+                'paths': sys.path,
+            })
 
+        return self.render('panels/versions.html', context)

--- a/flask_debugtoolbar/templates/panels/versions.html
+++ b/flask_debugtoolbar/templates/panels/versions.html
@@ -18,10 +18,10 @@
             </tr>
         {% else %}
             <tr>
-                <td>yolk</td>
+                <td>setuptools</td>
                 <td>NOT INSTALLED</td>
                 <td>&nbsp;</td>
-                <td>Install Yolk to display installed packages and version information</td>
+                <td>Install setuptools to display installed packages and version information</td>
             </tr>
         {% endfor %}
     </tbody>

--- a/flask_debugtoolbar/templates/panels/versions.html
+++ b/flask_debugtoolbar/templates/panels/versions.html
@@ -1,0 +1,28 @@
+<h4>Installed Packages</h4>
+<table>
+    <thead>
+        <tr>
+            <th>Package</th>
+            <th>Version</th>
+            <th>Develop?</th>
+            <th>Installed Path</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for package in packages %}
+            <tr class="{{ loop.cycle('flDebugOdd' 'flDebugEven') }}">
+                <td>{{ package.project_name }}</td>
+                <td>{{ package.version }}</td>
+                <td>{{ package.develop_mode }}</td>
+                <td>{{ package.location }}</td>
+            </tr>
+        {% else %}
+            <tr>
+                <td>yolk</td>
+                <td>NOT INSTALLED</td>
+                <td>&nbsp;</td>
+                <td>Install Yolk to display installed packages and version information</td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>


### PR DESCRIPTION
Versions panel update to display installed packages and version numbers. Relies on setuptools pkg_resources to discover ['active' packages ](http://pythonhosted.org/distribute/pkg_resources.html#workingset-objects) on sys.path
