### PR TITLE
Use '_external=True' to generate static_path url

### DIFF
--- a/flask_debugtoolbar/toolbar.py
+++ b/flask_debugtoolbar/toolbar.py
@@ -17,7 +17,8 @@ class DebugToolbar(object):
         self.panels = []
 
         self.template_context = {
-            'static_path': url_for('_debug_toolbar.static', filename='')
+            'static_path': url_for(
+                '_debug_toolbar.static', filename='', _external=True)
         }
 
         self.create_panels()
@@ -30,7 +31,8 @@ class DebugToolbar(object):
         activated = unquote(activated).split(';')
 
         for panel_class in self._iter_panels(current_app):
-            panel_instance = panel_class(jinja_env=self.jinja_env, context=self.template_context)
+            panel_instance = panel_class(
+                jinja_env=self.jinja_env, context=self.template_context)
 
             if panel_instance.dom_id() in activated:
                 panel_instance.is_active = True


### PR DESCRIPTION
With this change, instead of `static_path` being as something like `/_debug_toolbar/static/`, it's generated as `http://localhost/_debug_toolbar/static/` or `http://myserver.com/_debug_toolbar/static/` (when flask's `config['SERVER_NAME'] == 'myserver.com'`)

Motivation:
This breaks nothing and is more explicit. In work at the moment, we need to periodically save snapshots of webpages that have the flask debugtoolbar embedded in them. If they're saved and opened as flat .html files, the debugtoolbar breaks, since the browser cannot load `/_debug_toolbar/static/`. So, using a full URL instead of just a relative path fixes this, allowing the browser to load `/_debug_toolbar/static/` from the webserver from which the webpage was saved.