### PR TITLE
Display toolbar based on the presence of a cookie.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,6 +54,7 @@ Name                                  Description                             De
 ``DEBUG_TB_PANELS``                   List of module/class names of panels    enable all built-in panels
 ``DEBUG_TB_PROFILER_ENABLED``         Enable the profiler on all requests     ``False``, user-enabled
 ``DEBUG_TB_TEMPLATE_EDITOR_ENABLED``  Enable the template editor              ``False``
+``DEBUG_TB_COOKIE``                   Enable only for requests with cookie    ``None``
 ====================================  =====================================   ==========================
 
 To change one of the config options, set it in the Flask app's config like::

--- a/flask_debugtoolbar/__init__.py
+++ b/flask_debugtoolbar/__init__.py
@@ -99,6 +99,7 @@ class DebugToolbarExtension(object):
                 'flask_debugtoolbar.panels.logger.LoggingPanel',
                 'flask_debugtoolbar.panels.profiler.ProfilerDebugPanel',
             ),
+            'DEBUG_TB_COOKIE': None,
         }
 
     def dispatch_request(self):
@@ -131,6 +132,11 @@ class DebugToolbarExtension(object):
         hosts = current_app.config['DEBUG_TB_HOSTS']
         if hosts and request.remote_addr not in hosts:
             return False
+
+        # No cookie - no toolbar. 
+        debug_cookie = current_app.config['DEBUG_TB_COOKIE']
+        if debug_cookie and debug_cookie not in request.cookies:
+            return False 
 
         return True
 


### PR DESCRIPTION
This small change allows developers to only see the toolbar when they have a specific cookie set.

I have an app in a preview stage where there are some "regular" users that should not see the toolbar, but developers should still be able to. I didn't want separate deployments so I coded this in.

Works like so:
1. Set 'DEBUG_TB_COOKIE' to the name of the cookie you want to check for (e.g. `let_me_debug`).
2. Set a cookie for your site in your browser, e.g. `document.cookie="let_me_debug=1"`