### PR TITLE
Split calls column in profiler panel

### DIFF
--- a/flask_debugtoolbar/panels/profiler.py
+++ b/flask_debugtoolbar/panels/profiler.py
@@ -58,10 +58,8 @@ class ProfilerDebugPanel(DebugPanel):
                 info = stats.stats[func]
 
                 # Number of calls
-                if info[0] != info[1]:
-                    current['ncalls'] = '%d/%d' % (info[1], info[0])
-                else:
-                    current['ncalls'] = info[1]
+                current['ncalls'] = info[0]
+                current['pcalls'] = info[1]
 
                 # Total time
                 current['tottime'] = info[2] * 1000
@@ -118,6 +116,3 @@ class ProfilerDebugPanel(DebugPanel):
             'function_calls': self.function_calls,
         }
         return self.render('panels/profiler.html', context)
-
-
-

--- a/flask_debugtoolbar/templates/panels/profiler.html
+++ b/flask_debugtoolbar/templates/panels/profiler.html
@@ -2,6 +2,7 @@
   <thead>
     <tr>
       <th>Calls</th>
+      <th>Primitive Calls</th>
       <th>Total Time (ms)</th>
       <th>Per Call (ms)</th>
       <th>Cumulative Time (ms)</th>
@@ -13,6 +14,7 @@
     {% for row in function_calls %}
       <tr class="{{ loop.cycle('flDebugOdd', 'flDebugEven') }}">
         <td>{{ row.ncalls }}</td>
+        <td>{{ row.pcalls }}</td>
         <td>{{ row.tottime }}</td>
         <td>{{ '%.4f'|format(row.percall) }}</td>
         <td>{{ row.cumtime }}</td>


### PR DESCRIPTION
I split calls column in profiler panel into two different columns, because tablesorter don't work correctly for this column. It seems that tablesorter recognize the format "number/number" as MONTH/YEAR or DAY/MONTH and don't work with large values:
![screenshot from 2013-11-28 17 59 15](https://f.cloud.github.com/assets/276041/1640948/63bb6fc0-5846-11e3-9a51-a5d3dc8d0a6f.png)
