### PR TITLE
Add LICENSE file to MANIFEST.in / source bundle

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
+include LICENSE
 recursive-include flask_debugtoolbar/templates *.html
 recursive-include flask_debugtoolbar/static *


### PR DESCRIPTION
For the [conda-forge build](https://github.com/conda-forge/staged-recipes/pull/1493), it'd be nice to include a hard-link to the `LICENSE` file. Doing this requires a reference to `LICENSE` in the manifest so it can be included in the source build.