### PR TITLE
Exclude debugtoolbar rules from route list

### DIFF
--- a/flask_debugtoolbar/panels/route_list.py
+++ b/flask_debugtoolbar/panels/route_list.py
@@ -26,7 +26,8 @@ class RouteListDebugPanel(DebugPanel):
         return '%s %s' % (count, 'route' if count == 1 else 'routes')
 
     def process_request(self, request):
-        self.routes = list(current_app.url_map.iter_rules())
+        self.routes = [r for r in current_app.url_map.iter_rules()
+                       if not '_debug_toolbar' in r.rule]
 
     def content(self):
         return self.render('panels/route_list.html', {


### PR DESCRIPTION
The debug toolbar adds several routes to the list of routes for the application. It's in my opninion not really interesting to list them.