### PR TITLE
exclude Flask 1.1.0 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
               'flask_debugtoolbar.panels'
     ],
     install_requires=[
-        'Flask>=0.8',
+        'Flask>=0.8,!=1.1.0',
         'Blinker',
         'itsdangerous',
         'werkzeug',


### PR DESCRIPTION
Fixes #136 (and https://github.com/cookiecutter-flask/cookiecutter-flask/issues/517) by excluding Flask v.1.1.0 in `setup.py`.

Suggest merging this before bumping `flask-debugtoolbar` up a version on pypi.

Cheers!