### PR TITLE
Fix SQLAlchemy SELECT/EXPLAIN to use url_for to respect app prefixes.…

### DIFF
--- a/flask_debugtoolbar/__init__.py
+++ b/flask_debugtoolbar/__init__.py
@@ -1,7 +1,7 @@
 import os
 import warnings
 
-from flask import Blueprint, current_app, request, g, send_from_directory
+from flask import Blueprint, current_app, request, g, send_from_directory, url_for
 from flask.globals import _request_ctx_stack
 from jinja2 import Environment, PackageLoader
 from werkzeug.urls import url_quote_plus
@@ -53,6 +53,7 @@ class DebugToolbarExtension(object):
             loader=PackageLoader(__name__, 'templates'))
         self.jinja_env.filters['urlencode'] = url_quote_plus
         self.jinja_env.filters['printable'] = _printable
+        self.jinja_env.globals['url_for'] = url_for
 
         if app is not None:
             self.init_app(app)

--- a/flask_debugtoolbar/templates/panels/sqlalchemy.html
+++ b/flask_debugtoolbar/templates/panels/sqlalchemy.html
@@ -13,8 +13,8 @@
         <td>{{ '%.4f'|format(query.duration * 1000) }}</td>
         <td>
         {% if query.signed_query %}
-          <a class="remoteCall" href="/_debug_toolbar/views/sqlalchemy/sql_select?query={{ query.signed_query }}&amp;duration={{ query.duration|urlencode }}">SELECT</a><br />
-          <a class="remoteCall" href="/_debug_toolbar/views/sqlalchemy/sql_explain?query={{ query.signed_query }}&amp;duration={{ query.duration|urlencode }}">EXPLAIN</a><br />
+          <a class="remoteCall" href="{{ url_for('debugtoolbar.sql_select', explain=False, query=query.signed_query, duration=query.duration )}}">SELECT</a><br />
+          <a class="remoteCall" href="{{ url_for('debugtoolbar.sql_select', explain=True, query=query.signed_query, duration=query.duration )}}">EXPLAIN</a><br />
         {% endif %}
         </td>
         <td title="{{ query.context_long }}">


### PR DESCRIPTION
… Provide url_for to all toolbar templates.
In my situation the Flask app is running with a URL prefix, but the old SELECT/EXPLAIN links were hardcoded, so did not work.

Fixed by injecting url_for from flask into jinja globals to be available in all templates and use it in sqlalchemy.html template to fix the issue.