### PR TITLE
Switch to Flask's native CLI

### DIFF
--- a/example/app.py
+++ b/example/app.py
@@ -1,8 +1,6 @@
-import sys
-sys.path.insert(0, '.')
+# Run using: `FLASK_ENV=development flask run`
 
 from flask import Flask, render_template, redirect, url_for
-from flask_script import Manager
 from flask_sqlalchemy import SQLAlchemy
 from flask_debugtoolbar import DebugToolbarExtension
 
@@ -16,7 +14,6 @@ app.config['DEBUG_TB_INTERCEPT_REDIRECTS'] = True
 #)
 #app.config['DEBUG_TB_HOSTS'] = ('127.0.0.1', '::1' )
 app.config['SECRET_KEY'] = 'asd'
-app.config['DEBUG'] = True
 
 # TODO: This can be removed once flask_sqlalchemy 3.0 ships
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
@@ -46,8 +43,6 @@ def redirect_example():
     response.set_cookie('test_cookie', '1')
     return response
 
+
 if __name__ == "__main__":
     db.create_all()
-
-    manager = Manager(app)
-    manager.run()

--- a/test/basic_app.py
+++ b/test/basic_app.py
@@ -5,7 +5,6 @@ from flask_debugtoolbar import DebugToolbarExtension
 
 
 app = Flask('basic_app')
-app.debug = True
 app.config['SECRET_KEY'] = 'abc123'
 
 # TODO: This can be removed once flask_sqlalchemy 3.0 ships
@@ -29,7 +28,3 @@ def index():
     db.create_all()
     Foo.query.filter_by(id=1).all()
     return render_template('basic_app.html')
-
-
-if __name__ == '__main__':
-    app.run()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,5 @@
+import pytest
+
+@pytest.fixture(autouse=True)
+def mock_env_development(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "development")


### PR DESCRIPTION
Drop `flask_script` in favor of Flask's native CLI:
* https://flask.palletsprojects.com/en/master/cli/

This also requires changing the tests so that `pytest` mocks the env var
`FLASK_ENV` so that the test app starts in development mode. Unlike
normal test apps, we _do_ want development/debug mode, in addition to
testing mode.