### PR TITLE
Cleanup tox/travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: python
-python: "3.6"
+python: "3.8"
 env:
   - TOXENV=py27
-  - TOXENV=py36
+  - TOXENV=py38
 install:
   - pip install tox
 script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,stylecheck
+envlist = py27,py36,py37,py38,stylecheck
 
 [testenv]
 deps =
@@ -7,13 +7,13 @@ deps =
     Flask-SQLAlchemy
     Pygments
 commands =
-    py.test
+    pytest
 
 [testenv:stylecheck]
 deps =
-    flake8
+    pycodestyle
 commands =
-    flake8 flask_debugtoolbar test
+    pycodestyle flask_debugtoolbar test
 
-[flake8]
+[pycodestyle]
 max-line-length = 100


### PR DESCRIPTION
* Add more pythons to CI matrix
* `flake8` was renamed to `pycodestyle`
* `py.test` was deprecated in favor of `pytest`

In the near future I'd like to explore moving to Azure Pipelines, but
don't have the bandwidth to do that just yet.